### PR TITLE
Pin Drupal to 8.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "8.2.7",
+        "drupal/core": "8.2.*",
         "drush/drush": "~8.0",
         "drupal/console": "~1.0",
         "drupal/devel": "^1.0@beta",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "~8.0",
+        "drupal/core": "8.2.7",
         "drush/drush": "~8.0",
         "drupal/console": "~1.0",
         "drupal/devel": "^1.0@beta",


### PR DESCRIPTION
**GitHub Issue**:
* https://github.com/Islandora-CLAW/Crayfish/pull/20
* https://github.com/Islandora-CLAW/CLAW/issues/592

# What does this Pull Request do?

Pins Drupal to version 8.2.7.

We have an issue with Drupal 8.3.0, and I believe we need to wait until Rules has caught up to 8.3.0.

If we enable HAL as @DiegoPino has suggested [here](https://github.com/Islandora-CLAW/CLAW/issues/592#issuecomment-292148272), RDF UI cannot be enabled due to an issue with Rules downstream:

```
==> default: PHP Fatal error:  Class Drupal\rules\Ui\RulesUiDefinition contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Drupal\Component\Plugin\Definition\PluginDefinitionInterface::id, Drupal\Component\Plugin\Definition\PluginDefinitionInterface::getProvider) in /var/www/html/drupal/web/modules/contrib/rules/src/Ui/RulesUiDefinition.php on line 16
==> default: Drush command terminated abnormally due to an unrecoverable error.       [error]
==> default: Error: Class Drupal\rules\Ui\RulesUiDefinition contains 2 abstract
==> default: methods and must therefore be declared abstract or implement the
==> default: remaining methods
==> default: (Drupal\Component\Plugin\Definition\PluginDefinitionInterface::id,
==> default: Drupal\Component\Plugin\Definition\PluginDefinitionInterface::getProvider)
==> default: in
==> default: /var/www/html/drupal/web/modules/contrib/rules/src/Ui/RulesUiDefinition.php,
==> default: line 16
==> default: Do you want to update default key in system.theme config? (y/n): 
==> default: y
==> default: PHP Fatal error:  Class Drupal\rules\Ui\RulesUiDefinition contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Drupal\Component\Plugin\Definition\PluginDefinitionInterface::id, Drupal\Component\Plugin\Definition\PluginDefinitionInterface::getProvider) in /var/www/html/drupal/web/modules/contrib/rules/src/Ui/RulesUiDefinition.php on line 16
==> default: Drush command terminated abnormally due to an unrecoverable error.       [error]
==> default: Error: Class Drupal\rules\Ui\RulesUiDefinition contains 2 abstract
==> default: methods and must therefore be declared abstract or implement the
==> default: remaining methods
==> default: (Drupal\Component\Plugin\Definition\PluginDefinitionInterface::id,
==> default: Drupal\Component\Plugin\Definition\PluginDefinitionInterface::getProvider)
==> default: in
==> default: /var/www/html/drupal/web/modules/contrib/rules/src/Ui/RulesUiDefinition.php,
==> default: line 16
```

# What's new?
Nothing.

# How should this be tested?

* Update claw_vagrant [here](https://github.com/Islandora-CLAW/claw_vagrant/blob/master/scripts/drupal.sh#L20) to read `git clone -b issue-592 https://github.com/yorkulibraries/drupal-project drupal`
* `vagrant up`
* You should have a clean build, with Drupal 8.2.7

# Interested parties
@dannylamb @jonathangreen 