### PR TITLE
Update drupal core version to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "8.2.*",
+        "drupal/core": "8.3.*",
         "drush/drush": "~8.0",
         "drupal/console": "~1.0",
         "drupal/devel": "^1.0@beta",


### PR DESCRIPTION
## GitHub Issue

Part of:
https://github.com/Islandora-CLAW/CLAW/issues/594

Related:
https://github.com/Islandora-CLAW/jsonld/pull/20
https://github.com/Islandora-CLAW/islandora/pull/56

## What does this Pull Request do?

Updates the main `composer.json` to install Drupal 8.3 instead of 8.2. 

## Testing

This won't build correctly until the two related pull requests are merged, as we need both JSONLD to be updated to work with D8.3 and the Islandora module to pull in the correct version of Rules.

# Interested parties
@Islandora-CLAW/committers