### PR TITLE
Adding islandora_image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/media_entity": "^1.6",
         "drupal/media_entity_image": "^1.2",
         "drupal/bootstrap": "^3.1",
-        "islandora/islandora_collection": "dev-8.x-1.x"
+        "islandora/islandora_image": "dev-8.x-1.x"
     },
     "require-dev": {
         "behat/mink": "~1.7",


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/618

Blocked by https://github.com/Islandora-CLAW/claw_vagrant/pull/38

# What does this Pull Request do?

Adds islandora_image to the composer install process.

# What's new?
Just requiring `islandora_image` now that I put it on packagist.

# How should this be tested?

Download this code and do a `composer install`.  If it passes successfully, that's good enough.  The rest can be tested on the associated claw_vagrant pull https://github.com/Islandora-CLAW/claw_vagrant/pull/38.

# Interested parties
Here's an easy one @Islandora-CLAW/committers