### PR TITLE
adding search_api_solr and facets drupal modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
         "drupal/media_entity": "^1.6",
         "drupal/media_entity_image": "^1.2",
         "drupal/bootstrap": "^3.1",
+        "drupal/search_api_solr": "1.0.0",
+        "drupal/facets": "1.x-dev",
         "islandora/islandora_image": "dev-8.x-1.x"
     },
     "require-dev": {


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/CLAW/issues/698

# What does this Pull Request do?
This pull request adds the following module to the composer.json:
* [Solr Search](https://www.drupal.org/project/search_api_solr) 
* [Facets](https://www.drupal.org/project/facets)

# How should this be tested?
* In your local claw-vagrant, change the `claw_vagrant/scripts/drupal.sh` to point to this branch by modifying this line [here](https://github.com/Islandora-CLAW/claw_vagrant/blob/master/scripts/drupal.sh#L20) to  `git clone -b apache_solr https://github.com/Natkeeran/drupal-project drupal`
* vagrant up
* Verify that search_api_solr and facets modules are available here `/var/www/html/drupal/web/modules/contrib`

@Islandora-CLAW/committers 