### PR TITLE
Don't auto-scaffold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "^8.8.1",
         "drupal/core-composer-scaffold": "^8.8.0",
-        "drupal/devel": "^2.1",
         "drush/drush": "^9.7.1",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "^8.8.1",
         "drupal/core-composer-scaffold": "^8.8.0",
+        "drupal/devel": "^2.1",
         "drush/drush": "^9.7.1",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",
@@ -60,7 +61,6 @@
         ]
     },
     "extra": {
-        "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patchLevel": {
             "drupal/core": "-p2"

--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,9 @@
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
         "post-install-cmd": [
-            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
-            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         ]
     },
     "extra": {
+        "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patchLevel": {
             "drupal/core": "-p2"


### PR DESCRIPTION
**GitHub Issue**: Goes with https://github.com/Islandora-Devops/islandora-playbook/pull/147

# What does this Pull Request do?

Unregisters the scaffold scripts so they are no longer run every time we update.

# How should this be tested?

Set `drupal_composer_project_package: "islandora/drupal-project:dev-no-auto-scaffold"` in `group_vars/webserver/drupal.yml` and provision a server.

# Interested parties
@elizoller, @Islandora/8-x-committers
