### PR TITLE
Force Drush 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "^8.8.1",
         "drupal/core-composer-scaffold": "^8.8.0",
-        "drush/drush": "^9.7.1 | ^10.0.0",
+        "drush/drush": "^9.7.1",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"


### PR DESCRIPTION
**GitHub Issue**: Related to Islandora/islandora_defaults#26 and maybe Islandora/islandora#764

# What does this Pull Request do?

When we recently pullled from upstream we got 9 | 10, so travis is now getting drush 10. This PR specifically pins us to 9.

# Interested parties
@Islandora/8-x-committers
