### PR TITLE
Getting rid of drupal console for composer 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,18 @@ env:
 before_install:
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
-  - composer --verbose self-update --$COMPOSER_CHANNEL
-  - composer --version
+  - export COMPOSER_PATH="/home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/composer"
+  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose self-update --$COMPOSER_CHANNEL
+  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --version
 
 install:
-  - composer --verbose validate
-  - composer --verbose install
+  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose validate
+  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose install
 
 script:
-  - if [[ $RELEASE = dev ]]; then composer --verbose remove --no-update drupal/console; fi;
-  - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core:8.8.x-dev; composer --verbose require --no-update --dev drupal/core-dev:8.8.x-dev; fi;
-  - if [[ $RELEASE = dev ]]; then composer --verbose update; fi;
+  - if [[ $RELEASE = dev ]]; then COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose remove --no-update drupal/console; fi;
+  - if [[ $RELEASE = dev ]]; then COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose require --no-update drupal/core:8.8.x-dev; composer --verbose require --no-update --dev drupal/core-dev:8.8.x-dev; fi;
+  - if [[ $RELEASE = dev ]]; then COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH --verbose update; fi;
   - ./vendor/bin/drush site-install --verbose --yes --db-url=sqlite://tmp/site.sqlite
   - ./vendor/bin/drush runserver $SIMPLETEST_BASE_URL &
   - until curl -s $SIMPLETEST_BASE_URL; do true; done > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,3 @@ script:
   # Run a single unit test to verfiy the testing setup.
   - ./vendor/bin/phpunit -c ./web/core ./web/core/modules/system/tests/src/Unit/SystemRequirementsTest.php
   - ./vendor/bin/drush
-  - if [[ $RELEASE = stable ]]; then ./vendor/bin/drupal; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: 7.2
-      env: RELEASE=dev COMPOSER_CHANNEL=stable
+      env: RELEASE=stable COMPOSER_CHANNEL=snapshot
     - php: 7.3
+      env: RELEASE=stable COMPOSER_CHANNEL=snapshot
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: bionic 
 sudo: false
 
 php:
@@ -23,6 +23,10 @@ env:
     - RELEASE=stable COMPOSER_CHANNEL=snapshot
 
 before_install:
+  # https://www.drupal.org/project/drupal/issues/3107155
+  - sudo echo "deb http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse" >> /etc/apt/sources.list
+  - sudo apt-get update
+  - sudo apt-get -y install sqlite3/focal
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - export COMPOSER_PATH="/home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/composer"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": ">=7.0.8",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
-        "drupal/console": "^1.0.2",
         "drupal/core": "^8.8.1",
         "drupal/core-composer-scaffold": "^8.8.0",
         "drush/drush": "^9.7.1",

--- a/composer.json
+++ b/composer.json
@@ -18,24 +18,25 @@
     ],
     "require": {
         "php": ">=7.0.8",
-        "composer/installers": "^1.2",
-        "cweagans/composer-patches": "^1.6.5",
+        "composer/installers": "^1.9",
+        "cweagans/composer-patches": "^1.7",
         "drupal/core": "^8.8.1",
-        "drupal/core-composer-scaffold": "^8.8.0",
+        "drupal/core-composer-scaffold": "^8.8.1",
         "drush/drush": "^9.7.1",
-        "vlucas/phpdotenv": "^4.0",
-        "webflo/drupal-finder": "^1.0.0",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "vlucas/phpdotenv": "^5.1",
+        "webflo/drupal-finder": "^1.2",
+        "zaporylie/composer-drupal-optimizations": "^1.2"
     },
     "require-dev": {
         "drupal/core-dev": "^8.8.1"
     },
-    "conflict": {
+        "conflict": {
         "drupal/drupal": "*"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
+        "discard-changes": true,
         "sort-packages": true
     },
     "autoload": {
@@ -52,19 +53,13 @@
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
         "post-install-cmd": [
-            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
-            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ]
     },
     "extra": {
-        "composer-exit-on-patch-failure": true,
-        "patchLevel": {
-            "drupal/core": "-p2"
-        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
@@ -77,6 +72,12 @@
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
+        },
+        "composer-exit-on-patch-failure": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        },
+        "patches": {
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,9 +53,11 @@
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
         "post-install-cmd": [
+            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
+            "@composer drupal:scaffold",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "drupal/core-dev": "^8.8.1"
     },
-        "conflict": {
+    "conflict": {
         "drupal/drupal": "*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
**GitHub Issue**: Needed for https://github.com/Islandora/islandora/pull/806

# What does this Pull Request do?

Pull drupal console from our composer.json since it's not a hard dependency and fails with composer 2.

# How should this be tested?

It's already tested b/c Travis is happy with https://github.com/Islandora/islandora/pull/806

# Additional Notes:
After this is merged, I'll update https://github.com/Islandora/islandora/pull/806 to pull from 8.x-1.x.  Hopefully this unlocks the rest of the repos for Travis.

# Interested parties
@Islandora/8-x-committers
